### PR TITLE
Remove `asyncio` usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ adafruit_fruitjam
 adafruit_imageload
 adafruit_portalbase
 adafruit_usb_host_mouse
-asyncio


### PR DESCRIPTION
Uses a standard control loop to update keyboard and mouse input.
`atexit` callback added to detach mouse.