### PR TITLE
Added Pyboom! game

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -50,6 +50,14 @@ Speed dating sim for snakes written in CircuitPython for the Fruit Jam
 - Code Repository: [relic-se/Fruit_Jam_Ssspeed_Dating](https://github.com/relic-se/Fruit_Jam_Ssspeed_Dating)
 - Author: [Cooper Dalrymple](https://github.com/relic-se)
 
+### ![Pyboom! icon](https://raw.githubusercontent.com/Flobio75/Pyboom/main/bomb_icon.bmp) Pyboom!
+
+CircuitPython bomb dropping and bucket catching game for the Adafruit Fruit Jam.
+
+- Latest Release: [Download](https://github.com/Flobio75/Pyboom/releases/latest)
+- Code Repository: [Flobio75/Pyboom](https://github.com/Flobio75/Pyboom)
+- Author: [Flobio75](https://github.com/Flobio75)
+
 ## Music
 
 ### Fruit Jam Portable MIDI Synth

--- a/database/applications.json
+++ b/database/applications.json
@@ -3,7 +3,8 @@
         "ZContent/CPZ_Machine",
         "relic-se/Fruit_Jam_Fruitris",
         "relic-se/Fruit_Jam_Pong",
-        "relic-se/Fruit_Jam_Ssspeed_Dating"
+        "relic-se/Fruit_Jam_Ssspeed_Dating",
+        "Flobio75/Pyboom"
     ],
     "Music": [
         "samblenny/fruit-jam-portable-midi-synth"


### PR DESCRIPTION
Py-Boom is a fast-paced, 1-bit-style arcade game written in CircuitPython for the Adafruit Fruit Jam and other compatible display boards.

This game is a modern take on a classic "catcher" formula, featuring both a single-player mode against an AI and a competitive two-player versus mode.

More information: https://github.com/Flobio75/Pyboom